### PR TITLE
[CocoaPods] Update to CocoaPods 0.36 plugin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,15 @@ $ slather coverage -x --output-directory path/to/xml_report
 
 ### Coverage for code included via CocoaPods
 
-If you’re trying to compute the coverage of code that has been included via
-CocoaPods, you will need to tell slather where to find the source files for
-your Pod.
+If you're trying to compute the coverage of code that has been included via
+CocoaPods, you will need to tell CocoaPods to use the slather plugin by
+adding the following to your `Podfile`.
+
+```ruby
+plugin 'slather'
+```
+
+You will also need to tell slather where to find the source files for your Pod.
 
 ```yml
 # .slather.yml

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,6 +1,6 @@
 require 'slather'
 
-Pod::HooksManager.register(:post_install) do |installer_context|
+Pod::HooksManager.register('slather', :post_install) do |installer_context|
   sandbox_root = installer_context.sandbox_root
   sandbox = Pod::Sandbox.new(sandbox_root)
   project = Xcodeproj::Project.open(sandbox.project_path)

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "cocoapods", "~> 0.34"
+  spec.add_development_dependency "cocoapods", "~> 0.36.0"
   spec.add_development_dependency "json_spec", "~> 1.1.4"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "~> 0.20.0"
+  spec.add_dependency "xcodeproj", "~> 0.23.0"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end

--- a/spec/slather/cocoapods_plugin_spec.rb
+++ b/spec/slather/cocoapods_plugin_spec.rb
@@ -14,7 +14,7 @@ describe Slather do
       sandbox_root = 'Pods'
       sandbox = Pod::Sandbox.new(sandbox_root)
       context = Pod::Installer::HooksContext.generate(sandbox, [])
-      Pod::HooksManager.run(:post_install, context)
+      Pod::HooksManager.run(:post_install, context, {'slather' => nil})
     end
   end
 end


### PR DESCRIPTION
## :warning: *Awaiting CP 0.36 release * :warning: 

From CocoaPods 0.36 you will need to explicitly mark which plugins you want in your Podfile. So you will need something like the following in your Podfile.

```ruby
plugin 'slather'
```

Re: #29 /cc @neonichu 

---

@marklarr This also means we can provide metadata from the Podfile to the plugin hook, if we need to provide any configuration.

```ruby
plugin 'slather', :foo => :bar
```