### PR TITLE
Add CircleCI support

### DIFF
--- a/bin/slather
+++ b/bin/slather
@@ -12,6 +12,7 @@ Clamp do
     parameter "[xcodeproj]", "Path to the xcodeproj", :attribute_name => :xcodeproj_path
 
     option ["--travis", "-t"], :flag, "Indicate that the builds are running on Travis CI"
+    option ["--circleci"], :flag, "Indicate that the builds are running on CircleCI"
 
     option ["--coveralls", "-c"], :flag, "Post coverage results to coveralls"
     option ["--simple-output", "-s"], :flag, "Output coverage results to the terminal"
@@ -57,6 +58,8 @@ Clamp do
     def setup_service_name
       if travis?
         project.ci_service = :travis_ci
+      elsif circleci?
+        project.ci_service = :circleci
       end
     end
 

--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -11,6 +11,28 @@ module Slather
         ENV['TRAVIS_JOB_ID']
       end
       private :travis_job_id
+      
+      def circleci_job_id
+        ENV['CIRCLE_BUILD_NUM']
+      end
+      private :circleci_job_id
+      
+      def circleci_pull_request
+        ENV['CI_PULL_REQUEST']
+      end
+      private :circleci_pull_request
+      
+      def circleci_git_info
+        {
+          :head => {
+            :id => (ENV['CIRCLE_SHA1'] || ""),
+            :author_name => (ENV['CIRCLE_USERNAME'] || ""),
+            :message => (`git log --format=%B -n 1 HEAD`.chomp || "")
+          },
+          :branch => (ENV['CIRCLE_BRANCH'] || "")
+        }
+      end
+      private :circleci_git_info
 
       def coveralls_coverage_data
         if ci_service == :travis_ci || ci_service == :travis_pro
@@ -31,6 +53,24 @@ module Slather
             end
           else
             raise StandardError, "Environment variable `TRAVIS_JOB_ID` not set. Is this running on a travis build?"
+          end
+        elsif ci_service == :circleci
+          if circleci_job_id
+            coveralls_hash = {
+              :service_job_id => circleci_job_id,
+              :service_name => "circleci",
+              :repo_token => ci_access_token,
+              :source_files => coverage_files.map(&:as_json),
+              :git => circleci_git_info
+            }
+            
+            if circleci_pull_request != nil && circleci_pull_request.length > 0
+              coveralls_hash[:service_pull_request] = circleci_pull_request.split("/").last
+            end
+            
+            coveralls_hash.to_json
+          else
+            raise StandardError, "Environment variable `CIRCLE_BUILD_NUM` not set. Is this running on a circleci build?"
           end
         else
           raise StandardError, "No support for ci named #{ci_service}"


### PR DESCRIPTION
I've added support for [CircleCI](https://circleci.com), a neat CI service we use at work and which I've increasingly been using for my own personal projects. Like Travis, they offer free build containers for FOSS projects.

[Here](https://circleci.com/gh/splinesoft/SSDataSources/9) is a sample CircleCI+slather build in [one of my projects](https://github.com/splinesoft/SSDataSources) using my slather fork. The slathering, yea, it doth verily slather, but the build does not show on Coveralls. I am wondering if this is because:

- The latest CircleCI build for this project is 9, but the latest Travis build is 334, and perhaps Coveralls enforces increasing build number order?
- A missing access token or some other authorization requirement?
- Something else?

I would appreciate any suggestions you may have and your help in getting this to the finish line. Thanks! 