### PR TITLE
Include only commit subject in coveralls message

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,4 @@ Please make sure to follow our general coding style and add test coverage for ne
 
 * [@tpoulos](https://github.com/tpoulos), the perfect logo.
 * [@ayanonagon](https://github.com/ayanonagon) and [@kylef](https://github.com/kylef), feedback and testing.
+* [@jhersh](https://github.com/jhersh), CircleCI support.

--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -27,7 +27,7 @@ module Slather
           :head => {
             :id => (ENV['CIRCLE_SHA1'] || ""),
             :author_name => (ENV['CIRCLE_USERNAME'] || ""),
-            :message => (`git log --format=%B -n 1 HEAD`.chomp || "")
+            :message => (`git log --format=%s -n 1 HEAD`.chomp || "")
           },
           :branch => (ENV['CIRCLE_BRANCH'] || "")
         }


### PR DESCRIPTION
The current log format, `%B`, pulls in both the commit subject and raw body. For a merge commit, this results in a message like this that actually references two commits:

> Merge pull request #49 from splinesoft/circle
>
> Switch to CircleCI

This changes the coveralls commit message to just the commit subject, resulting in a cleaner message:

> Merge pull request #49 from splinesoft/circle
