### PR TITLE
Updates the Slather xcodeproj + nokogiri deps

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "~> 0.23.0"
-  spec.add_dependency "nokogiri", "~> 1.6.3"
+  spec.add_dependency "xcodeproj", "~> 0.23"
+  spec.add_dependency "nokogiri", "~> 1.6"
 end


### PR DESCRIPTION
When I updated to CocoaPods `0.37` I got errors around `xcodeproj`

```
---------------------------------------------
Error loading the plugin with path `/usr/local/var/rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/slather-1.7.0/lib/cocoapods_plugin.rb`.

Gem::LoadError - Unable to activate slather-1.7.0, because xcodeproj-0.24.0 conflicts with xcodeproj (~> 0.23.0)
/usr/local/var/rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems/specification.rb:2064:in `raise_if_conflicts'
/usr/local/var/rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems/specification.rb:1262:in `activate'
/usr/local/var/rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems.rb:196:in `rescue in try_activate'
/usr/local/var/rbenv/versions/2.1.3/lib/ruby/2.1.0/rubygems.rb:193:in `try_activate'
```

Because of the strict SemVer-ing. Your usage before says "accept anything that is `0.23.x` which is rare that we make minor patches. This has been updated to say that it allows any `0.x` ( another option is to have it be a minimum of 0.23. Open to changing.

Did the same for nokogiri, figure that one day it'll be easy to install :D