### PR TITLE
[Gemspec] Relaxed xcodeproj dependency

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "~> 0.23.0"
+  spec.add_dependency "xcodeproj", ">= 0.23.0"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end


### PR DESCRIPTION
CocoaPods [0.37.0.beta.1](https://github.com/CocoaPods/CocoaPods/releases/tag/0.37.0.beta.1) requires `xcodeproj ~> 0.24.0`, which is incompatible in a bundle with slather's requirement `xcodeproj ~> 0.23.0`. I've relaxed slather's dependency to hopefully let them live together in harmony. :dancers: 