### PR TITLE
Update .travis.yml example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ And then in your `.travis.yml` or `circle.yml`, call `slather` after a successfu
 ```yml
 # .travis.yml
 
-before_install: rvm use $RVM_RUBY_VERSION
-install: bundle install --without=documentation --path ../travis_bundle_dir
+before_install:
+  - gem install slather --no-ri --no-rdoc
 after_success: slather
 ```
 


### PR DESCRIPTION
So, as I have mentioned, I'm a Slather novice :)

But I definitely noticed that trying to run

    after_success: slather

without first installing the `slather` gem on Travis fails.

I also don't know what this was intended to do/why this was needed, so I removed it:

    before_install: rvm use $RVM_RUBY_VERSION
    install: bundle install --without=documentation --path ../travis_bundle_dir

If I'm missing something, please explain!