### PR TITLE
[ENV] Add support for passing the coveralls token via an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ To use Coveralls with Travis CI Pro (for private repos), add following lines alo
 # .slather.yml
 
 ci_service: travis_pro
-ci_access_token: <YOUR ACCESS TOKEN>
+coverage_access_token: <YOUR ACCESS TOKEN>
 ```
 
-Repo token can be found at [Coveralls](https://coveralls.io/) repo page. It can also be passed in via the `COVERAGE_ACCESS_TOKEN` environment var.
+The coverage token can be found at [Coveralls](https://coveralls.io/) repo page. Or it can be passed in via the `COVERAGE_ACCESS_TOKEN` environment var.
 
 ### Cobertura
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ ci_service: travis_pro
 ci_access_token: <YOUR ACCESS TOKEN>
 ```
 
-Repo token can be found at [Coveralls](https://coveralls.io/) repo page.
+Repo token can be found at [Coveralls](https://coveralls.io/) repo page. It can also be passed in via the `COVERAGE_ACCESS_TOKEN` environment var.
 
 ### Cobertura
 

--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -47,7 +47,7 @@ module Slather
               {
                 :service_job_id => travis_job_id,
                 :service_name => "travis-pro",
-                :repo_token => ci_access_token,
+                :repo_token => coverage_access_token,
                 :source_files => coverage_files.map(&:as_json)
               }.to_json
             end
@@ -59,7 +59,7 @@ module Slather
             coveralls_hash = {
               :service_job_id => circleci_job_id,
               :service_name => "circleci",
-              :repo_token => ci_access_token,
+              :repo_token => coverage_access_token,
               :source_files => coverage_files.map(&:as_json),
               :git => circleci_git_info
             }

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -105,7 +105,7 @@ module Slather
     end
 
     def configure_ci_access_token_from_yml
-      self.ci_access_token ||= (self.class.yml["ci_access_token"] || "")
+      self.ci_access_token ||= (ENV["COVERAGE_ACCESS_TOKEN"] || self.class.yml["ci_access_token"] || "")
     end
 
     def coverage_service=(service)

--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -19,7 +19,7 @@ end
 module Slather
   class Project < Xcodeproj::Project
 
-    attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :ci_access_token, :source_directory, :output_directory
+    attr_accessor :build_directory, :ignore_list, :ci_service, :coverage_service, :coverage_access_token, :source_directory, :output_directory
 
     alias_method :setup_for_coverage, :slather_setup_for_coverage
 
@@ -70,7 +70,7 @@ module Slather
       configure_build_directory_from_yml
       configure_ignore_list_from_yml
       configure_ci_service_from_yml
-      configure_ci_access_token_from_yml
+      configure_coverage_access_token_from_yml
       configure_coverage_service_from_yml
       configure_source_directory_from_yml
       configure_output_directory_from_yml
@@ -104,8 +104,8 @@ module Slather
       self.coverage_service ||= (self.class.yml["coverage_service"] || :terminal)
     end
 
-    def configure_ci_access_token_from_yml
-      self.ci_access_token ||= (ENV["COVERAGE_ACCESS_TOKEN"] || self.class.yml["ci_access_token"] || "")
+    def configure_coverage_access_token_from_yml
+      self.coverage_access_token ||= (ENV["COVERAGE_ACCESS_TOKEN"] || self.class.yml["coverage_access_token"] || "")
     end
 
     def coverage_service=(service)

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -44,7 +44,7 @@ describe Slather::CoverageService::Coveralls do
 
       it "should return valid json for coveralls coverage data" do
         fixtures_project.stub(:travis_job_id).and_return("9182")
-        fixtures_project.stub(:ci_access_token).and_return("abc123")
+        fixtures_project.stub(:coverage_access_token).and_return("abc123")
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"travis-pro\",\"repo_token\":\"abc123\"}").excluding("source_files")
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.send(:coverage_files).map(&:as_json).to_json).at_path("source_files")
       end
@@ -60,7 +60,7 @@ describe Slather::CoverageService::Coveralls do
     
       it "should return valid json for coveralls coverage data" do
         fixtures_project.stub(:circleci_job_id).and_return("9182")
-        fixtures_project.stub(:ci_access_token).and_return("abc123")
+        fixtures_project.stub(:coverage_access_token).and_return("abc123")
         fixtures_project.stub(:circleci_pull_request).and_return("1")
         fixtures_project.stub(:circleci_git_info).and_return({ :head => { :id => "ababa123", :author_name => "bwayne", :message => "hello" }, :branch => "master" })
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"circleci\",\"repo_token\":\"abc123\",\"service_pull_request\":\"1\",\"git\":{\"head\":{\"id\":\"ababa123\",\"author_name\":\"bwayne\",\"message\":\"hello\"},\"branch\":\"master\"}}").excluding("source_files")

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -243,12 +243,19 @@ describe Slather::Project do
     end
   end
 
-  describe "#configure_ci_access_token_from_yml" do
+  describe "#configure_ci_access_token" do
     it "should set the ci_access_token if it has been provided by the yml" do
       Slather::Project.stub(:yml).and_return({"ci_access_token" => "abc123"})
       expect(fixtures_project).to receive(:ci_access_token=).with("abc123")
       fixtures_project.configure_ci_access_token_from_yml
     end
+    
+    it "should set the ci_access_token if it is in the ENV" do
+      stub_const('ENV', ENV.to_hash.merge('COVERAGE_ACCESS_TOKEN' => 'asdf456'))
+      expect(fixtures_project).to receive(:ci_access_token=).with("asdf456")
+      fixtures_project.configure_ci_access_token_from_yml
+    end
+    
   end
 
   describe "#coverage_service=" do

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -243,17 +243,17 @@ describe Slather::Project do
     end
   end
 
-  describe "#configure_ci_access_token" do
-    it "should set the ci_access_token if it has been provided by the yml" do
-      Slather::Project.stub(:yml).and_return({"ci_access_token" => "abc123"})
-      expect(fixtures_project).to receive(:ci_access_token=).with("abc123")
-      fixtures_project.configure_ci_access_token_from_yml
+  describe "#configure_coverage_access_token" do
+    it "should set the coverage_access_token if it has been provided by the yml" do
+      Slather::Project.stub(:yml).and_return({"coverage_access_token" => "abc123"})
+      expect(fixtures_project).to receive(:coverage_access_token=).with("abc123")
+      fixtures_project.configure_coverage_access_token_from_yml
     end
     
-    it "should set the ci_access_token if it is in the ENV" do
+    it "should set the coverage_access_token if it is in the ENV" do
       stub_const('ENV', ENV.to_hash.merge('COVERAGE_ACCESS_TOKEN' => 'asdf456'))
-      expect(fixtures_project).to receive(:ci_access_token=).with("asdf456")
-      fixtures_project.configure_ci_access_token_from_yml
+      expect(fixtures_project).to receive(:coverage_access_token=).with("asdf456")
+      fixtures_project.configure_coverage_access_token_from_yml
     end
     
   end


### PR DESCRIPTION
Note: this happens to me locally too, https://github.com/venmo/slather/issues/74
Re: https://github.com/venmo/slather/issues/68 - I've added support for using an ENV var to pass your token in. Called it Coverage so that it can fit the other providers too.