### PR TITLE
Update used versions of CP and xcodeproj

### DIFF
--- a/slather.gemspec
+++ b/slather.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "cocoapods", "~> 0.36.0"
+  spec.add_development_dependency "cocoapods", "~> 0.37.0"
   spec.add_development_dependency "json_spec", "~> 1.1.4"
   spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "~> 0.23.0"
+  spec.add_dependency "xcodeproj", "~> 0.24.1"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end


### PR DESCRIPTION
Since CocoaPods 0.37 has been released, the used version of xcodeproj needs to be bumped to make the CP plugin usable/loadable again.