### PR TITLE
[CircleCI] Added new ENV variables for repo forks

### DIFF
--- a/lib/slather/coverage_service/coveralls.rb
+++ b/lib/slather/coverage_service/coveralls.rb
@@ -18,15 +18,20 @@ module Slather
       private :circleci_job_id
       
       def circleci_pull_request
-        ENV['CI_PULL_REQUEST']
+        ENV['CIRCLE_PR_NUMBER'] || ENV['CI_PULL_REQUEST'] || ""
       end
       private :circleci_pull_request
+      
+      def circleci_build_url
+        "https://circleci.com/gh/" + ENV['CIRCLE_PROJECT_USERNAME'] || "" + "/" + ENV['CIRCLE_PROJECT_REPONAME'] || "" + "/" + ENV['CIRCLE_BUILD_NUM'] || ""
+      end
+      private :circleci_build_url
       
       def circleci_git_info
         {
           :head => {
             :id => (ENV['CIRCLE_SHA1'] || ""),
-            :author_name => (ENV['CIRCLE_USERNAME'] || ""),
+            :author_name => (ENV['CIRCLE_PR_USERNAME'] || ENV['CIRCLE_USERNAME'] || ""),
             :message => (`git log --format=%s -n 1 HEAD`.chomp || "")
           },
           :branch => (ENV['CIRCLE_BRANCH'] || "")
@@ -61,7 +66,8 @@ module Slather
               :service_name => "circleci",
               :repo_token => ci_access_token,
               :source_files => coverage_files.map(&:as_json),
-              :git => circleci_git_info
+              :git => circleci_git_info,
+              :service_build_url => circleci_build_url
             }
             
             if circleci_pull_request != nil && circleci_pull_request.length > 0

--- a/spec/slather/coverage_service/coveralls_spec.rb
+++ b/spec/slather/coverage_service/coveralls_spec.rb
@@ -62,8 +62,9 @@ describe Slather::CoverageService::Coveralls do
         fixtures_project.stub(:circleci_job_id).and_return("9182")
         fixtures_project.stub(:ci_access_token).and_return("abc123")
         fixtures_project.stub(:circleci_pull_request).and_return("1")
+        fixtures_project.stub(:circleci_build_url).and_return("https://circleci.com/gh/Bruce/Wayne/1")
         fixtures_project.stub(:circleci_git_info).and_return({ :head => { :id => "ababa123", :author_name => "bwayne", :message => "hello" }, :branch => "master" })
-        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"circleci\",\"repo_token\":\"abc123\",\"service_pull_request\":\"1\",\"git\":{\"head\":{\"id\":\"ababa123\",\"author_name\":\"bwayne\",\"message\":\"hello\"},\"branch\":\"master\"}}").excluding("source_files")
+        expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql("{\"service_job_id\":\"9182\",\"service_name\":\"circleci\",\"repo_token\":\"abc123\",\"service_pull_request\":\"1\",\"service_build_url\":\"https://circleci.com/gh/Bruce/Wayne/1\",\"git\":{\"head\":{\"id\":\"ababa123\",\"author_name\":\"bwayne\",\"message\":\"hello\"},\"branch\":\"master\"}}").excluding("source_files")
         expect(fixtures_project.send(:coveralls_coverage_data)).to be_json_eql(fixtures_project.send(:coverage_files).map(&:as_json).to_json).at_path("source_files")
       end
     


### PR DESCRIPTION
CircleCI has some [new env variables](https://circleci.com/docs/environment-variables) that provide extra information when the build originates from a push to a fork of the repo. I've updated slather to take advantage of these variables when they are available.