### PR TITLE
Fix crash on invalid byte sequence in UTF-8

### DIFF
--- a/lib/slather/coverage_file.rb
+++ b/lib/slather/coverage_file.rb
@@ -71,7 +71,7 @@ module Slather
     end
 
     def cleaned_gcov_data
-      data = gcov_data.gsub(/^function(.*) called [0-9]+ returned [0-9]+% blocks executed(.*)$\r?\n/, '')
+      data = gcov_data.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').gsub(/^function(.*) called [0-9]+ returned [0-9]+% blocks executed(.*)$\r?\n/, '')
       data.gsub(/^branch(.*)$\r?\n/, '')
     end
 


### PR DESCRIPTION
Quick fix for this crash: 
```
/Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/coverage_file.rb:74:in `gsub': invalid byte sequence in UTF-8 (ArgumentError)
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/coverage_file.rb:74:in `cleaned_gcov_data'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/coverage_file.rb:62:in `line_coverage_data'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/coverage_file.rb:97:in `num_lines_testable'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/coverage_file.rb:109:in `percentage_lines_tested'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/project.rb:57:in `each'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/project.rb:57:in `max_by'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/project.rb:57:in `block in dedupe'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/project.rb:57:in `map'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/project.rb:57:in `dedupe'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/project.rb:51:in `coverage_files'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/lib/slather/coverage_service/gutter_json_output.rb:14:in `post'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/bin/slather:67:in `post'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/bin/slather:37:in `execute'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-0.6.5/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-0.6.5/lib/clamp/command.rb:67:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-0.6.5/lib/clamp/command.rb:132:in `run'
	from /Library/Ruby/Gems/2.0.0/gems/clamp-0.6.5/lib/clamp.rb:6:in `Clamp'
	from /Library/Ruby/Gems/2.0.0/gems/slather-1.7.1/bin/slather:6:in `<top (required)>'
	from /usr/bin/slather:23:in `load'
	from /usr/bin/slather:23:in `<main>'
```

I'm not a Ruby developer so there could be a better way to fix this.
