### PR TITLE
Fixed dependency conflict with CocoaPods v0.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master
 
+## v1.8.1
+* Fixed dependency conflict with CocoaPods v0.38
+* Updated usage of cocoapods plugin API since it has changed in v0.38
+  [Julian Krumow](https://github.com/tarbrain)
+  [#93](https://github.com/venmo/slather/pull/93)
+
 ## v1.7.0
 * Objective-C++ support  
   [ben-ng](https://github.com/ben-ng)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Fixed dependency conflict with CocoaPods v0.38
 * Updated usage of cocoapods plugin API since it has changed in v0.38
   [Julian Krumow](https://github.com/tarbrain)
-  [#93](https://github.com/venmo/slather/pull/93)
+  [#95](https://github.com/venmo/slather/pull/95)
 
 ## v1.7.0
 * Objective-C++ support  

--- a/README.md
+++ b/README.md
@@ -204,4 +204,4 @@ Please make sure to follow our general coding style and add test coverage for ne
 * [@ayanonagon](https://github.com/ayanonagon) and [@kylef](https://github.com/kylef), feedback and testing.
 * [@jhersh](https://github.com/jhersh), CircleCI support.
 * [@ixnixnixn](https://github.com/ixnixnixn), html support.
-* [@tarbrain](https://github.com/tarbrain), Cobertura support, bugfixing.
+* [@tarbrain](https://github.com/tarbrain), Cobertura support and bugfixing.

--- a/README.md
+++ b/README.md
@@ -204,3 +204,4 @@ Please make sure to follow our general coding style and add test coverage for ne
 * [@ayanonagon](https://github.com/ayanonagon) and [@kylef](https://github.com/kylef), feedback and testing.
 * [@jhersh](https://github.com/jhersh), CircleCI support.
 * [@ixnixnixn](https://github.com/ixnixnixn), html support.
+* [@tarbrain](https://github.com/tarbrain), Cobertura support, bugfixing.

--- a/slather.gemspec
+++ b/slather.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "cocoapods", "~> 0.37.0"
+  spec.add_development_dependency "cocoapods", "~> 0.38.0"
   spec.add_development_dependency "json_spec", "~> 1.1.4"
   spec.add_development_dependency "equivalent-xml", "~> 0.5.1"
 
   spec.add_dependency "clamp", "~> 0.6"
-  spec.add_dependency "xcodeproj", "~> 0.24.1"
+  spec.add_dependency "xcodeproj", "~> 0.26.2"
   spec.add_dependency "nokogiri", "~> 1.6.3"
 end

--- a/spec/slather/cocoapods_plugin_spec.rb
+++ b/spec/slather/cocoapods_plugin_spec.rb
@@ -13,7 +13,7 @@ describe Slather do
       # Execute the post_install hook via CocoaPods
       sandbox_root = 'Pods'
       sandbox = Pod::Sandbox.new(sandbox_root)
-      context = Pod::Installer::HooksContext.generate(sandbox, [])
+      context = Pod::Installer::PostInstallHooksContext.generate(sandbox, [])
       Pod::HooksManager.run(:post_install, context, {'slather' => nil})
     end
   end


### PR DESCRIPTION
Hi there,

I fixed the following issues with cocoapods v0.38:

- updated dependencies `cocoapods` and `xcodeproj`
- changed usage of `cocoapods` plugin API which has changed in version `0.38.x`

Fixes issue #94 