### PR TITLE
Make codecove example read the report output by slather

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ before_install: rvm use $RVM_RUBY_VERSION
 install: bundle install --without=documentation --path ../travis_bundle_dir
 after_success: 
   - slather
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -f path/to/xml_report/cobertura.xml
 ```
 
 ```yml


### PR DESCRIPTION
The codecov bash uploader has the option to specify the file to upload https://github.com/codecov/codecov-bash/blob/master/codecov#L32
The example as is would have the bash uploader search for coverage files but if you specify where the cobertura report is output then you know which file to have codecov upload.