### PR TITLE
.xcodeproj instead of .pbxproj in error

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -47,7 +47,7 @@ module Slather
       end.compact
 
       if coverage_files.empty?
-        raise StandardError, "No coverage files found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.pbxproj`"
+        raise StandardError, "No coverage files found. Are you sure your project is setup for generating coverage files? Try `slather setup your/project.xcodeproj`"
       else
         dedupe(coverage_files)
       end


### PR DESCRIPTION
Is the suggestion for `project.pbxproj` correct? I shouldn't be `project.xcodeproj` instead?